### PR TITLE
Fix Gradle wrapper permissions in CI

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
+    - name: Grant execute permission for gradlew
+      run: chmod +x ./gradlew
+
     - name: Build with Gradle
       run: ./gradlew build
 


### PR DESCRIPTION
## Summary
- make sure `gradlew` has execute permissions in the CI workflow

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_684abada24f08332af450a3e17dce9be