### PR TITLE
Add compile workflow

### DIFF
--- a/.github/workflows/compile-release.yml
+++ b/.github/workflows/compile-release.yml
@@ -1,0 +1,20 @@
+name: Compile on Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+    - name: Build
+      run: ./gradlew build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds the Kotlin project whenever a release is created

## Testing
- `./gradlew build --no-daemon` *(fails: compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b899f71048332ad4c2178bc7b753d