### PR TITLE
Add Maven publish configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Após a compilação, execute o exemplo com:
 ./gradlew runExample
 ```
 
+### 📦 Publicar no GitHub Packages
+Defina as variáveis de ambiente `USERNAME` e `TOKEN` (o `TOKEN` pode ser o seu
+`GITHUB_TOKEN`) e execute:
+
+```bash
+./gradlew publish
+```
+
 ## 📎 Exemplo
 ```bash
 var a 10 | var b 5 | add a b total | print Resultado: $total

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '2.1.20'
     id 'java-library'
+    id 'maven-publish'
 }
 
 group = 'pt.clilib'
@@ -41,4 +42,22 @@ tasks.register("runExample", JavaExec) {
     description = "Runs the CLI example"
     classpath = sourceSets.example.runtimeClasspath
     mainClass.set("MainKt")
+}
+
+publishing {
+    publications {
+        create("gpr", MavenPublication) {
+            from(components.java)
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/RafaPear/CLILib")
+            credentials {
+                username = System.getenv("USERNAME") ?: findProperty("gpr.user")?.toString() ?: ""
+                password = System.getenv("TOKEN") ?: findProperty("gpr.key")?.toString() ?: ""
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `maven-publish` plugin with GitHub Packages repository
- update README with instructions for publishing

## Testing
- `./gradlew build --no-daemon`
- `./gradlew publish --no-daemon --stacktrace` *(fails: Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_684b8e5168308332a4b6a82a4c37494e