### PR TITLE
Expose commands and protect buffer variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ CLILib é uma biblioteca Kotlin para criar interfaces de linha de comandos exten
 import pt.clilib.App
 fun main() {
     val app = App()
+    // load all commands
     app.registerDefaultCommands()
+    // or choose groups like utils and directory commands
+    // app.registerDefaultCommands("--utils --dir")
     app.runtimeCLI()
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '2.1.20'
     id 'java-library'
     id 'maven-publish'
+    id 'org.jetbrains.dokka' version '1.9.20'
 }
 
 group = 'pt.clilib'
@@ -22,6 +23,11 @@ test {
 java {
     withSourcesJar()
     withJavadocJar()
+}
+
+tasks.named('javadocJar') {
+    dependsOn tasks.named('dokkaJavadoc')
+    from(tasks.named('dokkaJavadoc').get().outputDirectory)
 }
 
 kotlin {

--- a/src/main/kotlin/pt/clilib/App.kt
+++ b/src/main/kotlin/pt/clilib/App.kt
@@ -6,6 +6,7 @@ import pt.clilib.cmdUtils.commands.file.*
 import pt.clilib.cmdUtils.commands.directory.*
 import pt.clilib.cmdUtils.commands.functions.*
 import pt.clilib.cmdUtils.commands.varOp.*
+import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 import java.awt.Color
 import java.io.File
@@ -99,8 +100,29 @@ class App() {
         }
     }
 
-    fun registerDefaultCommands() {
-        // Register all default cmdUtils.commands from cmdUtils.commands package
-        CmdRegister.registerAll(defaultCommands)
+    fun registerDefaultCommands(options: String = "") {
+        val tokens = options.split(Regex("\\s+")).filter { it.isNotBlank() }
+        if (tokens.isEmpty()) {
+            CmdRegister.registerAll(defaultCommands)
+            return
+        }
+
+        val load = mutableSetOf<Command>()
+
+        if ("--all" in tokens || "-all" in tokens) {
+            load.addAll(defaultCommands)
+        } else {
+            if ("--cli" in tokens) load.addAll(listOf(CdCmd, ClrCmd, ExitCmd, HelpCmd, PrintCmd, VersionCmd, WaitCmd, WaitForCmd, MkCmd, WindowCmd, BufferCmd))
+            if ("--file" in tokens) load.addAll(listOf(MkFileCmd, MkTemplateCmd, EditCmd, DelFileCmd))
+            if ("--dir" in tokens) load.addAll(listOf(CdCmd, LsCmd, MkDirCmd, DelDirCmd))
+            if ("--var" in tokens) load.addAll(listOf(VarCmd, AddVarCmd, SubVarCmd, DivVarCmd, MultVarCmd, ExprVarCmd))
+            if ("--utils" in tokens) load.addAll(listOf(LoadScriptCmd, MeasureCmd))
+        }
+
+        if (load.isEmpty()) load.addAll(defaultCommands)
+
+        CmdRegister.registerAll(load.toList())
     }
+
+    fun registerDefaultCommands() = registerDefaultCommands("")
 }

--- a/src/main/kotlin/pt/clilib/VarRegister.kt
+++ b/src/main/kotlin/pt/clilib/VarRegister.kt
@@ -1,6 +1,9 @@
 package pt.clilib
+
+internal const val LAST_CMD_KEY = "lastCmdDump"
+
 internal object VarRegister {
-    private val vars = mutableMapOf<String, Any>()
+    private val vars = mutableMapOf<String, Any?>(LAST_CMD_KEY to null)
     /**
      * Registers a variable with a given name and value.
      *
@@ -10,6 +13,10 @@ internal object VarRegister {
     fun register(name: String, value: Any) {
         if (name.isBlank()) {
             throw IllegalArgumentException("Variable name cannot be blank.")
+        }
+        if (name == LAST_CMD_KEY) {
+            println("Warning: '$LAST_CMD_KEY' is reserved and cannot be registered via CLI")
+            return
         }
         vars[name] = value
     }
@@ -49,6 +56,10 @@ internal object VarRegister {
         if (name.isBlank()) {
             throw IllegalArgumentException("Variable name cannot be blank.")
         }
+        if (name == LAST_CMD_KEY) {
+            println("Warning: '$LAST_CMD_KEY' cannot be removed from the register")
+            return
+        }
         if (vars.remove(name) != null) {
             println("Unregistered variable: $name")
         } else {
@@ -61,7 +72,7 @@ internal object VarRegister {
      *
      * @return A map containing all variable names and their values.
      */
-    fun all(): Map<String, Any> {
+    fun all(): Map<String, Any?> {
         return vars.toMap()
     }
 
@@ -69,10 +80,20 @@ internal object VarRegister {
         if (name.isBlank()) {
             throw IllegalArgumentException("Variable name cannot be blank.")
         }
+        if (name == LAST_CMD_KEY) {
+            println("Warning: '$LAST_CMD_KEY' cannot be modified via CLI")
+            return
+        }
         if (vars.containsKey(name)) {
             vars[name] = value
         } else {
             println("Variable $name not found. Use register to create it first.")
         }
+    }
+
+    fun lastCmdDump(): Any? = vars[LAST_CMD_KEY]
+
+    fun setLastCmdDump(value: Any?) {
+        vars[LAST_CMD_KEY] = value
     }
 }

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/BufferCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/BufferCmd.kt
@@ -1,12 +1,11 @@
 package pt.clilib.cmdUtils.commands.cli
 
-import jdk.internal.org.jline.utils.Colors
+import pt.clilib.VarRegister
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.CYAN
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
 import pt.clilib.tools.joinToString
-import pt.clilib.tools.lastCmdDump
 import pt.clilib.tools.validateArgs
 
 // Command that manipulates the lastCmdDump variable buffer, which is used to store the last command's output.
@@ -24,15 +23,16 @@ object BufferCmd : Command {
         // Use Colors
         when (args.getOrNull(0)?.lowercase()) {
             "--clear", "-c" -> {
-                lastCmdDump = null
+                VarRegister.setLastCmdDump(null)
                 println("${CYAN}Buffer cleared.$RESET")
             }
             "--dump", "-d" -> {
-                if (lastCmdDump == null) {
+                val dump = VarRegister.lastCmdDump()
+                if (dump == null) {
                     println("${CYAN}Buffer is empty.$RESET")
                 } else {
                     println("${CYAN}Buffer content:$RESET")
-                    println(lastCmdDump.joinToString())
+                    println(dump.joinToString())
                 }
             }
             "--help", "-h" -> {

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/ClrCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/ClrCmd.kt
@@ -6,7 +6,7 @@ import pt.clilib.tools.*
 /**
 * Limpa o ecrã do terminal imprimindo várias linhas vazias.
 */
-internal object ClrCmd : Command {
+object ClrCmd : Command {
     override val description = "Clear the screen"
     override val longDescription = "Clear the screen by printing multiple empty lines."
     override val usage = "clr"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/ExitCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/ExitCmd.kt
@@ -12,7 +12,7 @@ import kotlin.system.exitProcess
  *
  * Não recebe argumentos.
  */
-internal object ExitCmd : Command {
+object ExitCmd : Command {
     override val description = "Exit the application"
     override val usage = "exit"
     override val aliases = listOf("e", "exit")

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/HelpCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/HelpCmd.kt
@@ -13,7 +13,7 @@ import pt.clilib.tools.*
  *
  * Não necessita de argumentos.
  */
-internal object HelpCmd : Command {
+object HelpCmd : Command {
     override val description = "Show help information"
     override val longDescription = "Show all available cmdUtils.commands and their usage."
     override val usage = "help [command]"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/MkCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/MkCmd.kt
@@ -9,7 +9,7 @@ import pt.clilib.tools.cmdParser
 import pt.clilib.tools.readJsonFile
 import pt.clilib.tools.validateArgs
 
-internal object MkCmd : Command {
+object MkCmd : Command {
     override val description = "Cria um comando simples a partir de um ficheiro JSON"
     override val longDescription = "Permite criar comandos simples que apenas imprimem uma mensagem fixa, definida num ficheiro JSON."
     override val usage = "mkcmd <ficheiro.json>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/PrintCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/PrintCmd.kt
@@ -6,7 +6,7 @@ import pt.clilib.tools.*
 /**
  * Imprime no terminal todos os argumentos passados ao comando.
  */
-internal object PrintCmd : Command {
+object PrintCmd : Command {
     override val description = "Print argument"
     override val longDescription = "Print the provided arguments to the terminal."
     override val usage = "print <words>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/VersionCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/VersionCmd.kt
@@ -10,7 +10,7 @@ import pt.clilib.tools.version
 /**
  * Mostra a versão da aplicação e os créditos dos autores.
  */
-internal object VersionCmd : Command {
+object VersionCmd : Command {
 
     override val description = "Show version information and credits"
     override val usage = "version"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WaitCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WaitCmd.kt
@@ -13,7 +13,7 @@ import pt.clilib.tools.*
  * Aceita um argumento que é o número de milissegundos a esperar.
  */
 
-internal object WaitCmd : Command {
+object WaitCmd : Command {
     override val description = "Wait for a specified time"
     override val longDescription = "Wait for a specified time in milliseconds."
     override val usage = "wait <milliseconds>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WaitForCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WaitForCmd.kt
@@ -13,7 +13,7 @@ import pt.clilib.tools.*
  * Aceita um argumento opcional que é a mensagem a ser exibida antes de esperar pela entrada do utilizador.
  */
 
-internal object WaitForCmd : Command {
+object WaitForCmd : Command {
         override val description = "Wait for user input"
         override val longDescription = "Wait for user input before proceeding."
         override val usage = "wfu [message]"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WindowCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WindowCmd.kt
@@ -7,7 +7,7 @@ import pt.clilib.tools.validateArgs
 import pt.clilib.tools.root
 import java.awt.Color
 
-internal object WindowCmd : Command {
+object WindowCmd : Command {
     override val description = "Open a new terminal window"
     override val longDescription = "Open a new terminal window with the same session."
     override val usage = "window"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/CdCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/CdCmd.kt
@@ -7,7 +7,7 @@ import java.io.File
 /**
  * Muda o diretório atual para outro especificado ou para o diretório anterior com "..".
  */
-internal object CdCmd : Command {
+object CdCmd : Command {
     override val description = "Change directory"
     override val longDescription = "Change the current directory to a specified relative directory or to the parent directory with '..'."
     override val usage = "cd <directory>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/DelDirCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/DelDirCmd.kt
@@ -3,7 +3,7 @@ package pt.clilib.cmdUtils.commands.directory
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 
-internal object DelDirCmd : Command {
+object DelDirCmd : Command {
     override val description = "Delete a directory"
     override val longDescription = "Deletes the specified directory from the filesystem."
     override val usage = "deldir <directory_path>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/LsCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/LsCmd.kt
@@ -7,7 +7,7 @@ import java.io.File
 /**
  * Lista os ficheiros e pastas do diretório atual ou de um diretório relativo passado como argumento.
  */
-internal object LsCmd : Command {
+object LsCmd : Command {
     override val description = "List files in the current directory"
     override val longDescription = "List files in the current directory or a specified relative directory."
     override val usage = "ls [directory]"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/MkDirCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/MkDirCmd.kt
@@ -4,7 +4,7 @@ import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 import java.io.File
 
-internal object MkDirCmd : Command {
+object MkDirCmd : Command {
     override val description = "Cria um diretório"
     override val longDescription = "Cria um diretório com o nome especificado."
     override val usage = "mkdir <diretório>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/DelFileCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/DelFileCmd.kt
@@ -3,7 +3,7 @@ package pt.clilib.cmdUtils.commands.file
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 
-internal object DelFileCmd : Command {
+object DelFileCmd : Command {
     override val description = "Delete a file"
     override val longDescription = "Deletes the specified file from the filesystem."
     override val usage = "delfile <file_path>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/EditCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/EditCmd.kt
@@ -8,7 +8,7 @@ import pt.clilib.tools.root
 import pt.clilib.tools.validateArgs
 import java.io.File
 
-internal object EditCmd : Command {
+object EditCmd : Command {
     override val description = "Edit a file"
     override val longDescription = "Edit a file using the default editor."
     override val usage = "edit <file>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkFileCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkFileCmd.kt
@@ -4,7 +4,7 @@ import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 import java.io.File
 
-internal object MkFileCmd : Command {
+object MkFileCmd : Command {
     override val description = "Cria um arquivo"
     override val longDescription = "Cria um arquivo com o nome especificado."
     override val usage = "mkfile <arquivo>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkTemplateCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkTemplateCmd.kt
@@ -4,7 +4,7 @@ import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 import java.io.File
 
-internal object MkTemplateCmd : Command {
+object MkTemplateCmd : Command {
     override val description = "Cria um ficheiro JSON de template para comandos customizados"
     override val longDescription = "Gera um ficheiro JSON de exemplo para criar comandos simples via mkcmd."
     override val usage = "mkcmdtemplate <nome_do_ficheiro.json>"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/LoadScriptCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/LoadScriptCmd.kt
@@ -14,7 +14,7 @@ import java.io.File
  * Aceita um argumento que é o nome do ficheiro de script a ser carregado.
  */
 
-internal object LoadScriptCmd : Command {
+object LoadScriptCmd : Command {
 
         override val description = "Load a script file"
         override val longDescription = "Load and execute a script file containing a series of cmdUtils.commands."

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/MeasureCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/MeasureCmd.kt
@@ -1,5 +1,6 @@
 package pt.clilib.cmdUtils.commands.functions
 
+import pt.clilib.VarRegister
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 import kotlin.time.measureTime
@@ -13,7 +14,7 @@ import kotlin.time.measureTime
  *
  * Aceita qualquer comando como argumento. Útil para testes de desempenho.
  */
-internal object MeasureCmd : Command {
+object MeasureCmd : Command {
     override val description = "Measure the time taken by a command"
     override val longDescription = "Measure the time taken to execute a command. Useful for performance testing."
     override val usage = "measure <command>"
@@ -28,7 +29,7 @@ internal object MeasureCmd : Command {
         println("${YELLOW}Measuring time for command: ${newArgs}${RESET}")
 
         val time = measureTime { cmdParser(newArgs) }
-        lastCmdDump = time
+        VarRegister.setLastCmdDump(time)
 
         println("${GREEN}Time taken: ${time.inWholeMilliseconds} ms${RESET} \n")
         return true

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/VarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/VarCmd.kt
@@ -2,6 +2,7 @@ package pt.clilib.cmdUtils.commands.functions
 
 import com.sun.tools.javac.tree.TreeInfo.args
 import pt.clilib.VarRegister
+import pt.clilib.LAST_CMD_KEY
 import pt.clilib.cmdUtils.CmdRegister
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
@@ -13,7 +14,7 @@ import kotlin.text.toFloatOrNull
 import kotlin.text.toIntOrNull
 import kotlin.text.toLongOrNull
 
-internal object VarCmd : Command {
+object VarCmd : Command {
     override val description = "Create or modify a variable"
     override val longDescription = "Create or modify a variable with the given name and value. "
     override val usage = "var <name> [args]"
@@ -86,6 +87,10 @@ internal object VarCmd : Command {
                     println("${RED}Error: Invalid number of arguments for delete command.${RESET}")
                     return false
                 }
+                if (args[1] == LAST_CMD_KEY) {
+                    println("${YELLOW}Warning: '$LAST_CMD_KEY' cannot be removed.${RESET}")
+                    return false
+                }
                 VarRegister.unregister(args[1])
             }
             "-l", "--list" -> {
@@ -105,6 +110,10 @@ internal object VarCmd : Command {
     }
 
     private fun assignValue(name: String, value: String): Boolean {
+        if (name == LAST_CMD_KEY) {
+            println("${YELLOW}Warning: '$LAST_CMD_KEY' cannot be modified via CLI${RESET}")
+            return false
+        }
         val newValue = when {
             value.isEmpty() -> null
             value.all { it.isDigit() } -> value.toIntOrNull() ?: value.toLongOrNull() ?: value.toDoubleOrNull() ?: value.toFloatOrNull()
@@ -125,14 +134,19 @@ internal object VarCmd : Command {
     }
 
     private fun assignLastCmdDump(name: String) : Boolean {
-        if (lastCmdDump == null) return false
+        val dump = VarRegister.lastCmdDump() ?: return false
+
+        if (name == LAST_CMD_KEY) {
+            println("${YELLOW}Warning: '$LAST_CMD_KEY' cannot be modified via CLI${RESET}")
+            return false
+        }
 
         if (VarRegister.isRegistered(name)) {
-            VarRegister.modify(name, lastCmdDump!!)
-            println("${GREEN}Variable '${name}' modified with value: $lastCmdDump${RESET}")
+            VarRegister.modify(name, dump)
+            println("${GREEN}Variable '${name}' modified with value: $dump${RESET}")
         } else {
-            VarRegister.register(name, lastCmdDump!!)
-            println("${GREEN}Variable '${name}' registered with value: $lastCmdDump${RESET}")
+            VarRegister.register(name, dump)
+            println("${GREEN}Variable '${name}' registered with value: $dump${RESET}")
         }
         return true
     }

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/AddVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/AddVarCmd.kt
@@ -1,11 +1,12 @@
 package pt.clilib.cmdUtils.commands.varOp
 
 import pt.clilib.VarRegister
+import pt.clilib.LAST_CMD_KEY
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 
 // Adds two variables together, or creates a new variable with the result.
-internal object AddVarCmd : Command{
+object AddVarCmd : Command{
     override val description = "Add two variables together"
     override val longDescription = "Adds the values of two variables and creates a new variable with the result."
     override val usage = "add <var1> <var2> <resultVar>"
@@ -35,13 +36,17 @@ internal object AddVarCmd : Command{
                 return false
             }
         }
-        lastCmdDump = result
+        VarRegister.setLastCmdDump(result)
         if (args.size < 3) {
             println("${GREEN}Result: $result${RESET}")
             return true
         }
         else {
-            VarRegister.register(args[2], result)
+            if (args[2] == LAST_CMD_KEY) {
+                VarRegister.setLastCmdDump(result)
+            } else {
+                VarRegister.register(args[2], result)
+            }
             println("${GREEN}Added ${args[0]} and ${args[1]} to create ${args[2]} with value $result.${RESET}")
         }
         return true

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/DivVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/DivVarCmd.kt
@@ -1,10 +1,11 @@
 package pt.clilib.cmdUtils.commands.varOp
 
 import pt.clilib.VarRegister
+import pt.clilib.LAST_CMD_KEY
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 
-internal object DivVarCmd : Command {
+object DivVarCmd : Command {
     override val description = "Divide two variables"
     override val longDescription = "Divides the value of one variable by another and creates a new variable with the result."
     override val usage = "div <var1> <var2> <resultVar>"
@@ -37,12 +38,16 @@ internal object DivVarCmd : Command {
                 return false
             }
         }
-        lastCmdDump = result
+        VarRegister.setLastCmdDump(result)
         if (args.size < 3) {
             println("${GREEN}Result: $result${RESET}")
             return true
         } else {
-            VarRegister.register(args[2], result)
+            if (args[2] == LAST_CMD_KEY) {
+                VarRegister.setLastCmdDump(result)
+            } else {
+                VarRegister.register(args[2], result)
+            }
             println("${GREEN}Divided ${args[0]} by ${args[1]} to create ${args[2]} with value $result.${RESET}")
         }
         return true

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/ExprVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/ExprVarCmd.kt
@@ -1,9 +1,10 @@
 package pt.clilib.cmdUtils.commands.varOp
 
+import pt.clilib.VarRegister
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 
-internal object ExprVarCmd : Command {
+object ExprVarCmd : Command {
     override val description = "Evaluate an expression"
     override val longDescription = "Evaluates a mathematical expression."
     override val usage = "expr <expression>"
@@ -17,7 +18,7 @@ internal object ExprVarCmd : Command {
 
         try {
             val result = ExprParser().parse(expression)
-            lastCmdDump = result
+            VarRegister.setLastCmdDump(result)
             println("${GREEN}Result: $result${RESET}")
         } catch (e: Exception) {
             println("${RED}Error evaluating expression: ${e.message}${RESET}")

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/MultVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/MultVarCmd.kt
@@ -1,10 +1,11 @@
 package pt.clilib.cmdUtils.commands.varOp
 
 import pt.clilib.VarRegister
+import pt.clilib.LAST_CMD_KEY
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 
-internal object MultVarCmd : Command {
+object MultVarCmd : Command {
     override val description = "Multiply two variables"
     override val longDescription = "Multiplies the value of one variable by another and creates a new variable with the result."
     override val usage = "mult <var1> <var2> <resultVar>"
@@ -33,12 +34,16 @@ internal object MultVarCmd : Command {
                 return false
             }
         }
-        lastCmdDump = result
+        VarRegister.setLastCmdDump(result)
         if (args.size < 3) {
             println("${GREEN}Result: $result${RESET}")
             return true
         } else {
-            VarRegister.register(args[2], result)
+            if (args[2] == LAST_CMD_KEY) {
+                VarRegister.setLastCmdDump(result)
+            } else {
+                VarRegister.register(args[2], result)
+            }
             println("${GREEN}Multiplied ${args[0]} by ${args[1]} to create ${args[2]} with value $result.${RESET}")
         }
         return true

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/SubVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/SubVarCmd.kt
@@ -1,10 +1,11 @@
 package pt.clilib.cmdUtils.commands.varOp
 
 import pt.clilib.VarRegister
+import pt.clilib.LAST_CMD_KEY
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
 
-internal object SubVarCmd : Command {
+object SubVarCmd : Command {
     override val description = "Subtract two variables"
     override val longDescription = "Subtracts the value of one variable from another and creates a new variable with the result."
     override val usage = "sub <var1> <var2> <resultVar>"
@@ -33,12 +34,16 @@ internal object SubVarCmd : Command {
                 return false
             }
         }
-        lastCmdDump = result
+        VarRegister.setLastCmdDump(result)
         if (args.size < 3) {
             println("${GREEN}Result: $result${RESET}")
             return true
         } else {
-            VarRegister.register(args[2], result)
+            if (args[2] == LAST_CMD_KEY) {
+                VarRegister.setLastCmdDump(result)
+            } else {
+                VarRegister.register(args[2], result)
+            }
             println("${GREEN}Subtracted ${args[1]} from ${args[0]} to create ${args[2]} with value $result.${RESET}")
         }
         return true

--- a/src/main/kotlin/pt/clilib/tools/Global.kt
+++ b/src/main/kotlin/pt/clilib/tools/Global.kt
@@ -13,4 +13,3 @@ internal const val commentCode = "//"
 var root: String = File(System.getProperty("user.dir")).absolutePath + File.separator
     get() = field.trimEnd('/', '\\') + File.separator
 
-var lastCmdDump: Any? = null

--- a/src/main/kotlin/pt/clilib/tools/Utils.kt
+++ b/src/main/kotlin/pt/clilib/tools/Utils.kt
@@ -118,7 +118,9 @@ internal fun String.replaceVars(auto : Boolean = false): String {
     }
     // Replace buffer variable
     if (nInput.contains(str)) {
-        nInput = nInput.replace(str, lastCmdDump.joinToString())
+        val dump = VarRegister.lastCmdDump()
+        if (dump != null)
+            nInput = nInput.replace(str, dump.joinToString())
     }
     return nInput
 }


### PR DESCRIPTION
## Summary
- expose command objects as public
- move `lastCmdDump` into `VarRegister`
- add option-based command registration and document usage
- generate Kotlin documentation with Dokka
- adapt buffer handling to use new variable location

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_684c59927c188332a729a8685caa8d83