### PR TITLE
Include documentation in jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,13 @@ tasks.named('javadocJar') {
     from(tasks.named('dokkaJavadoc').get().outputDirectory)
 }
 
+tasks.named('jar') {
+    dependsOn tasks.named('dokkaJavadoc')
+    from(tasks.named('dokkaJavadoc').get().outputDirectory) {
+        into('docs')
+    }
+}
+
 kotlin {
     jvmToolchain(21)
 }


### PR DESCRIPTION
## Summary
- ensure Dokka output is bundled in the main jar

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_684c70fee86483328d559852d4aee678