### PR TITLE
Enable docs via Maven Local

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,12 @@ tasks.register("runExample", JavaExec) {
     mainClass.set("MainKt")
 }
 
+// Automatically publish the library to Maven Local after building so that
+// projects depending on it can access the documentation and sources JARs.
+tasks.named("build") {
+    finalizedBy(tasks.named("publishToMavenLocal"))
+}
+
 publishing {
     publications {
         create("gpr", MavenPublication) {


### PR DESCRIPTION
## Summary
- automatically run `publishToMavenLocal` after building

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_684c994f2a2c8332837ae69793e1e87d