### PR TITLE
Refactor command registry and suggestions

### DIFF
--- a/src/main/kotlin/pt/clilib/cmdUtils/CmdRegister.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/CmdRegister.kt
@@ -4,17 +4,21 @@ import pt.clilib.tools.RESET
 import pt.clilib.tools.YELLOW
 
 object CmdRegister {
-    private val commands = mutableListOf<Command>()
+    private val aliasMap = mutableMapOf<String, Command>()
+    private val commands = linkedSetOf<Command>()
 
     fun register(command: Command) {
-        val cmdAliases = commands.map { it.aliases }.flatten()
-        if(!command.aliases.any { alias -> alias in cmdAliases })
-            commands.add(command)
-        else
-            println("${YELLOW}Warning: Command '${command.aliases.first()}' is already registered. Skipping registration.$RESET")
+        val existing = command.aliases.firstOrNull { aliasMap.containsKey(it.lowercase()) }
+        if (existing != null) {
+            println("${YELLOW}Warning: Command '$existing' is already registered. Skipping registration.$RESET")
+            return
+        }
+        command.aliases.forEach { aliasMap[it.lowercase()] = command }
+        commands.add(command)
     }
 
     fun unregister(command: Command) {
+        aliasMap.entries.removeIf { it.value == command }
         commands.remove(command)
     }
 
@@ -26,10 +30,11 @@ object CmdRegister {
         commands.forEach { unregister(it) }
     }
 
-    fun all(): List<Command> = commands
+    fun all(): List<Command> = commands.toList()
 
-    fun find(alias: String): Command? {
-        return commands.find { alias.lowercase() in it.aliases.map(String::lowercase) }
-    }
+    fun find(alias: String): Command? = aliasMap[alias.lowercase()]
+
+    fun findSimilar(prefix: String): String? =
+        aliasMap.keys.firstOrNull { it.startsWith(prefix.lowercase()) }
 }
 

--- a/src/main/kotlin/pt/clilib/tools/Utils.kt
+++ b/src/main/kotlin/pt/clilib/tools/Utils.kt
@@ -77,21 +77,13 @@ fun cmdParser(input: String?, args: List<String> = emptyList(), supress : Boolea
             return false
         }
         val command = CmdRegister.find(token[0])
-        var similar : String? = null
-        CmdRegister.all().forEach {
-            it.aliases.forEach { i ->
-                if (i.startsWith(token[0]))
-                    similar = i
-            }
-        }
+        val similar = CmdRegister.findSimilar(token[0])
         if (command == null) {
             if (!supress) {
-                if (similar == null) {
+                if (similar == null)
                     println("${RED}App Error: Unknown command ${token[0]}$RESET")
-                }
-                else {
+                else
                     println("${RED}App Error: Unknown command ${token[0]}. Did you mean '$similar'?$RESET")
-                }
             }
             return false
         }


### PR DESCRIPTION
## Summary
- refactor CmdRegister to map aliases to commands for faster lookup
- simplify cmdParser by using new `findSimilar` helper

## Testing
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_6850a525e0188332a6ec9ef0d219cd61