### PR TITLE
Improve command cleanup

### DIFF
--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/FunCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/FunCmd.kt
@@ -9,7 +9,6 @@ import pt.clilib.tools.RESET
 import pt.clilib.tools.YELLOW
 import pt.clilib.tools.cmdParser
 import pt.clilib.tools.validateArgs
-import kotlin.text.removeSurrounding
 
 object FunCmd : Command {
     override val description = "Create a function"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/VarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/VarCmd.kt
@@ -1,18 +1,11 @@
 package pt.clilib.cmdUtils.commands.functions
 
-import com.sun.tools.javac.tree.TreeInfo.args
 import pt.clilib.VarRegister
 import pt.clilib.LAST_CMD_KEY
 import pt.clilib.cmdUtils.CmdRegister
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
-import kotlin.text.all
-import kotlin.text.first
-import kotlin.text.isEmpty
-import kotlin.text.toDoubleOrNull
-import kotlin.text.toFloatOrNull
-import kotlin.text.toIntOrNull
-import kotlin.text.toLongOrNull
+
 
 object VarCmd : Command {
     override val description = "Create or modify a variable"

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/WhileCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/WhileCmd.kt
@@ -1,22 +1,13 @@
 package pt.clilib.cmdUtils.commands.functions
 
-import com.sun.org.apache.xpath.internal.XPathAPI.eval
-import com.sun.tools.javac.tree.TreeInfo
-import com.sun.tools.javac.tree.TreeInfo.args
-import pt.clilib.VarRegister
 import pt.clilib.cmdUtils.Command
-import pt.clilib.tools.GREEN
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
 import pt.clilib.tools.cmdParser
 import pt.clilib.tools.eval
-import pt.clilib.tools.joinToString
 import pt.clilib.tools.replaceVars
 import pt.clilib.tools.validateArgs
-import java.util.concurrent.locks.Condition
 
-// This object represents a command that is used to create a while loop in the CLI.
-// It also reads the keyword break to exit the loop.
 object WhileCmd : Command {
     override val description = "Create a while loop"
     override val longDescription = "Create a while loop with the given condition. The loop will continue until the condition is false."
@@ -31,8 +22,6 @@ object WhileCmd : Command {
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
-        // Implement the logic for the while loop here.
-        // This is a placeholder implementation.
         try {
             val newCmd = args.drop(1)
                 .joinToString(" ")

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/ExprVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/ExprVarCmd.kt
@@ -3,9 +3,6 @@ package pt.clilib.cmdUtils.commands.varOp
 import pt.clilib.VarRegister
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
-import kotlin.math.nextDown
-import kotlin.math.nextUp
-import kotlin.math.roundToInt
 
 object ExprVarCmd : Command {
     override val description = "Evaluate an expression"


### PR DESCRIPTION
## Summary
- remove unused imports from various commands
- simplify `WhileCmd` implementation

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6850a6e7c3388332a2dd90a172d1814f