### PR TITLE
Improve command validation and cleanup imports

### DIFF
--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/FunCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/FunCmd.kt
@@ -7,6 +7,7 @@ import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
 import pt.clilib.tools.YELLOW
+import pt.clilib.tools.isValidIdentifier
 import pt.clilib.tools.cmdParser
 import pt.clilib.tools.validateArgs
 import kotlin.text.removeSurrounding
@@ -43,15 +44,9 @@ object FunCmd : Command {
             // Default behavior: register the function with the given name and value.
             val newArgs = args.drop(1).joinToString(" ")
 
-            if (args[0][0].isDigit()){
-                println("${RED}Error: Function name '${args[0]}' must start with a letter.${RESET}")
+            if (!isValidIdentifier(args[0])) {
+                println("${RED}Error: Invalid function name '${args[0]}'.${RESET}")
                 return false
-            }
-            args[0].map {
-                if(!(it.isLetter() || it.isDigit() || it == '_')) {
-                    println("${RED}Error: Function name '${args[0]}' must start with a letter and can only contain letters, digits, and underscores.${RESET}")
-                    return false
-                }
             }
 
             val value = newArgs.trim()

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/VarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/VarCmd.kt
@@ -1,18 +1,10 @@
 package pt.clilib.cmdUtils.commands.functions
-
-import com.sun.tools.javac.tree.TreeInfo.args
 import pt.clilib.VarRegister
 import pt.clilib.LAST_CMD_KEY
 import pt.clilib.cmdUtils.CmdRegister
 import pt.clilib.cmdUtils.Command
 import pt.clilib.tools.*
-import kotlin.text.all
-import kotlin.text.first
-import kotlin.text.isEmpty
-import kotlin.text.toDoubleOrNull
-import kotlin.text.toFloatOrNull
-import kotlin.text.toIntOrNull
-import kotlin.text.toLongOrNull
+import pt.clilib.tools.isValidIdentifier
 
 object VarCmd : Command {
     override val description = "Create or modify a variable"
@@ -48,15 +40,9 @@ object VarCmd : Command {
             // Default behavior: register the variable with the given name and value.
             val newArgs = args.drop(1).joinToString(" ")
 
-            if (args[0][0].isDigit()){
-                println("${RED}Error: Variable name '${args[0]}' must start with a letter.${RESET}")
+            if (!isValidIdentifier(args[0])) {
+                println("${RED}Error: Invalid variable name '${args[0]}'.${RESET}")
                 return false
-            }
-            args[0].map {
-                if(!(it.isLetter() || it.isDigit() || it == '_')) {
-                    println("${RED}Error: Variable name '${args[0]}' must start with a letter and can only contain letters, digits, and underscores.${RESET}")
-                    return false
-                }
             }
 
             if(cmdParser(newArgs.lowercase(), supress = true)) {

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/WhileCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/WhileCmd.kt
@@ -1,19 +1,12 @@
 package pt.clilib.cmdUtils.commands.functions
 
-import com.sun.org.apache.xpath.internal.XPathAPI.eval
-import com.sun.tools.javac.tree.TreeInfo
-import com.sun.tools.javac.tree.TreeInfo.args
-import pt.clilib.VarRegister
 import pt.clilib.cmdUtils.Command
-import pt.clilib.tools.GREEN
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
 import pt.clilib.tools.cmdParser
 import pt.clilib.tools.eval
-import pt.clilib.tools.joinToString
 import pt.clilib.tools.replaceVars
 import pt.clilib.tools.validateArgs
-import java.util.concurrent.locks.Condition
 
 // This object represents a command that is used to create a while loop in the CLI.
 // It also reads the keyword break to exit the loop.

--- a/src/main/kotlin/pt/clilib/tools/Utils.kt
+++ b/src/main/kotlin/pt/clilib/tools/Utils.kt
@@ -45,6 +45,16 @@ internal fun validateArgs(args: List<String>, command: Command): Boolean {
 }
 
 /**
+ * Validates whether [name] is a valid identifier for variables or functions.
+ * A valid name starts with a letter and may contain letters, digits or
+ * underscores.
+ */
+internal fun isValidIdentifier(name: String): Boolean {
+    if (name.isEmpty() || !name.first().isLetter()) return false
+    return name.all { it.isLetterOrDigit() || it == '_' }
+}
+
+/**
  * Função que processa os comandos introduzidos pelo utilizador. Retorna true caso a execução tenha sido bem sucedida.
  * False caso contrário.
  *


### PR DESCRIPTION
## Summary
- simplify variable/function name validation with new `isValidIdentifier`
- clean unused imports in `WhileCmd`
- reuse new validation in `VarCmd` and `FunCmd`
- run Gradle tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6850a6e7c3388332a2dd90a172d1814f