### PR TITLE
Improve command interface and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # 🧩 CLILib
 
-CLILib é uma biblioteca Kotlin para criar interfaces de linha de comandos extensíveis. Permite definir comandos, variáveis e scripts de forma simples e composável.
+CLILib is a Kotlin library for building extensible command line interfaces. It allows you to define commands, variables and scripts in a simple and composable way.
 
-## 🚀 Funcionalidades
-- Registo dinâmico de comandos
-- Suporte a scripts `.ppc`
-- Variáveis globais e operações matemáticas
-- Encadeamento de comandos com `|`
-- Criação de comandos via ficheiros JSON
-- Comandos prontos como `print`, `var`, `cd`, `ls` e `loadscript`
+## 🚀 Features
+- Dynamic command registration
+- Support for `.ppc` scripts
+- Global variables and math operations
+- Command chaining with `|`
+- Create commands from JSON files
+- Built-in commands like `print`, `var`, `cd`, `ls` and `loadscript`
 
-## 🛠️ Início rápido
+## 🛠️ Quick start
 ```kotlin
 import pt.clilib.App
 fun main() {
@@ -23,13 +23,13 @@ fun main() {
 }
 ```
 
-Também é possível executar comandos a partir de um ficheiro:
+You can also execute commands from a file:
 
 ```kotlin
 app.runFromFile("Scripts/setup.ppc")
 ```
 
-### 📥 Instalação
+### 📥 Installation
 
 ```bash
 git clone https://github.com/RafaPear/CLILib.git
@@ -37,39 +37,39 @@ cd CLILib
 ./gradlew build
 ```
 
-O arquivo JAR resultante fica em `build/libs`. Por exemplo:
+The resulting JAR file is placed in `build/libs`. For example:
 
 ```
 build/libs/CLILib-1.0-SNAPSHOT.jar
 ```
 
-Após a compilação, execute o exemplo com:
+After the build, run the example with:
 
 ```bash
 ./gradlew runExample
 ```
 
-### 📦 Publicar no GitHub Packages
-Defina as variáveis de ambiente `USERNAME` e `TOKEN` (o `TOKEN` pode ser o seu
-`GITHUB_TOKEN`) e execute:
+### 📦 Publish to GitHub Packages
+Define the environment variables `USERNAME` and `TOKEN` (the `TOKEN` can be your
+`GITHUB_TOKEN`) and run:
 
 ```bash
 ./gradlew publish
 ```
 
-## 📎 Exemplo
+## 📎 Example
 ```bash
-var a 10 | var b 5 | add a b total | print Resultado: $total
+var a 10 | var b 5 | add a b total | print Result: $total
 ```
 
-## 📚 Documentação
-Consulte a [Wiki do projeto](https://github.com/RafaPear/CLILib/wiki) para mais detalhes sobre a arquitetura, lista de comandos e guias de extensão.
+## 📚 Documentation
+Check the [project Wiki](https://github.com/RafaPear/CLILib/wiki) for details about the architecture, list of commands and extension guides.
 
-## 🤝 Contribuições
-Contribuições são bem‑vindas! Veja [Como Contribuir](https://github.com/RafaPear/CLILib/wiki/🤝-Como-Contribuir).
+## 🤝 Contributions
+Contributions are welcome! See [How to Contribute](https://github.com/RafaPear/CLILib/wiki/🤝-Como-Contribuir).
 
-## 📄 Licença
-Distribuído sob a [MIT License](https://opensource.org/licenses/MIT).
+## 📄 License
+Distributed under the [MIT License](https://opensource.org/licenses/MIT).
 
-## ✨ Créditos
-Desenvolvido com ❤️ por Rafael Vermelho Pereira
+## ✨ Credits
+Developed with ❤️ by Rafael Vermelho Pereira

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,18 +1,18 @@
-# Visão Geral
+# Overview
 
-Esta pasta reproduz parte da informação disponível na wiki do projeto.
+This folder mirrors part of the information available in the project wiki.
 
-## Estrutura do Projeto
-- `src/main/kotlin` contém a implementação principal.
-- `Commands` guarda exemplos de comandos em JSON.
-- `Scripts` tem ficheiros `.ppc` para demonstração.
+## Project Structure
+- `src/main/kotlin` contains the main implementation.
+- `Commands` holds example commands in JSON format.
+- `Scripts` includes `.ppc` files for demonstration.
 
-## Comandos principais
-- `help` – lista de comandos e descrição.
-- `var` – cria variáveis que podem ser usadas nos scripts.
-- `loadscript` – executa um ficheiro `.ppc`.
+## Main commands
+- `help` – list commands and description.
+- `var` – create variables used in scripts.
+- `loadscript` – execute a `.ppc` file.
 
-## Execução
-Após compilar o projeto com `./gradlew build`, pode correr o exemplo com `./gradlew run`.
+## Execution
+After building the project with `./gradlew build`, you can run the example using `./gradlew run`.
 
-Para mais detalhes consulte a wiki original no GitHub.
+For more details see the original GitHub wiki.

--- a/src/main/kotlin/pt/clilib/cmdUtils/Command.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/Command.kt
@@ -1,92 +1,53 @@
 package pt.clilib.cmdUtils
 
 /**
- * Representa um comando que pode ser executado na ‘interface’ de linha de comandos (CLI).
- *
- * Esta ‘interface’ define a estrutura que todos os comandos devem seguir, incluindo:
- * - A descrição textual do comando, visível no menu de ajuda.
- * - A forma de utilização do comando e os seus atalhos (aliases).
- * - O número mínimo e máximo de argumentos aceites.
- * - Se o comando espera ficheiros como entrada e qual a extensão esperada.
- *
- * A função [run] é chamada sempre que o comando é executado no CLI, recebendo os argumentos como uma lista de strings
- * e devolvendo um valor booleano que indica o sucesso ou falha da execução.
- *
- * !! OBRIGATÓRIOS !!
- * Os campos `description`, `usage`, `aliases` e a função `run` são de implementação obrigatória.
- * Todos os outros campos são opcionais.
- *
- * !! EXPLICAÇÃO DAS PROPRIEDADES !!
- *
- * - aliases: contém os diferentes nomes que podem ser usados para invocar o comando principal.
- *
- * - Args (min e max): definem o número mínimo e máximo de argumentos que o comando aceita.
- *   Nota: se `maxArgs` for definido como −1, o comando aceita um número ilimitado de argumentos.
- *   O mínimo tem obrigatoriamente de ser menor ou igual ao máximo. Se forem diferentes, isso
- *   indica que o comando tem argumentos opcionais.
- *   Exemplo: se `minArgs = 1` e `maxArgs = 2`, o primeiro argumento é obrigatório e o segundo é opcional.
- *
- *   Se `minArgs` e `maxArgs` não forem definidos, assume-se que o comando não recebe argumentos
- *   (`minArgs = 0`, `maxArgs = 0`).
- *
- * - requiresFile e fileExtension: indicam se o comando espera caminhos de ficheiros como argumentos.
- *   Se `requiresFile = true`, será feita a validação da extensão dos ficheiros através de `fileExtension`.
- *   Por defeito, considera-se `requiresFile = false` e `fileExtension = ""`.
- *
- * - run: função principal do comando. Deve ser sobreposta para definir o comportamento.
- *   Por convenção (definida por nós), recomenda-se:
- *     1. Validar os argumentos com `tools.validateArgs` no início da função;
- *     2. Usar `println` apenas para mensagens relevantes (como erros), e não para texto aleatório.
- *        A ideia é que o `core` trate da lógica principal.
+ * Represents a command that can be executed by the CLI application.
+ * A command has descriptive metadata and a [run] function that
+ * performs the desired behaviour when invoked.
  */
-
 interface Command {
-    /** Define a descrição do comando que será apresentada na última
-     coluna do menu Help*/
+    /** Command metadata. */
+    val info: CommandInfo
+
+    /** Short command description shown in help. */
     val description: String
+        get() = info.description
 
-    /** Define a descrição longa do comando que será apresentada quando
-     * o comando help é chamado com argumentos*/
+    /** Detailed description for extended help. */
     val longDescription: String
-        get() = description
+        get() = info.longDescription
 
-    /**Define o modo de utilização do comando que será apresentado
-    na primeira coluna do menu Help
-    */val usage: String
+    /** Usage string displayed in help. */
+    val usage: String
+        get() = info.usage
 
-    /**Define as diferentes formas de chamamento do comando que serão
-    apresentadas na segunda coluna do menu Help*/
+    /** Command aliases used to invoke this command. */
     val aliases: List<String>
+        get() = info.aliases
 
-    /**Define o número mínimo de argumentos.
-
-    DEFAULT = 0*/
+    /** Minimum number of arguments accepted. */
     val minArgs: Int
-        get() = 0
+        get() = info.minArgs
 
-    /**Define o número máximo de argumentos.
-
-    DEFAULT = 0*/
+    /** Maximum number of arguments accepted (-1 for unlimited). */
     val maxArgs: Int
-        get() = 0
+        get() = info.maxArgs
 
+    /** Optional argument-based subcommands. */
     val commands: List<String>
-        get() = emptyList()
+        get() = info.commands
 
-    /**Define se o comando espera receber ficheiros.
-
-    DEFAULT = false*/
+    /** Whether file paths are expected as arguments. */
     val requiresFile: Boolean
-        get() = false
+        get() = info.requiresFile
 
-    /**Define se a extensão de ficheiro que o comando espera receber.
-
-    DEFAULT = ""*/
+    /** Expected file extension when [requiresFile] is true. */
     val fileExtension: String
-        get() = ""
+        get() = info.fileExtension
 
-    /**Função run é executada quando o comando é chamado no CLI.
-    Recebe como parâmetros os argumentos [args] do comando e retorna um
-    [Boolean] que indica se a execução do comando foi bem sucedida ou não.*/
+    /**
+     * Executes the command with the provided [args].
+     * Returns true if the execution succeeded, false otherwise.
+     */
     fun run(args: List<String>): Boolean
 }

--- a/src/main/kotlin/pt/clilib/cmdUtils/CommandInfo.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/CommandInfo.kt
@@ -1,0 +1,13 @@
+package pt.clilib.cmdUtils
+
+data class CommandInfo(
+    val description: String,
+    val usage: String,
+    val aliases: List<String>,
+    val longDescription: String = description,
+    val minArgs: Int = 0,
+    val maxArgs: Int = 0,
+    val commands: List<String> = emptyList(),
+    val requiresFile: Boolean = false,
+    val fileExtension: String = ""
+)

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/BufferCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/BufferCmd.kt
@@ -2,6 +2,7 @@ package pt.clilib.cmdUtils.commands.cli
 
 import pt.clilib.VarRegister
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.CYAN
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
@@ -10,12 +11,14 @@ import pt.clilib.tools.validateArgs
 
 // Command that manipulates the lastCmdDump variable buffer, which is used to store the last command's output.
 object BufferCmd : Command {
-    override val description = "Manipulate the command buffer"
-    override val longDescription = "This command allows you to manipulate the last command's output buffer."
-    override val usage = "buffer [--clear|--dump]"
-    override val aliases = listOf("buffer", "buf")
-    override val minArgs = 0
-    override val maxArgs = 1
+    override val info = CommandInfo(
+        description = "Manipulate the command buffer",
+        longDescription = "This command allows you to manipulate the last command's output buffer.",
+        usage = "buffer [--clear|--dump]",
+        aliases = listOf("buffer", "buf"),
+        minArgs = 0,
+        maxArgs = 1
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/ClrCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/ClrCmd.kt
@@ -1,20 +1,23 @@
 package pt.clilib.cmdUtils.commands.cli
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 
 /**
 * Limpa o ecrã do terminal imprimindo várias linhas vazias.
 */
 object ClrCmd : Command {
-    override val description = "Clear the screen"
-    override val longDescription = "Clear the screen by printing multiple empty lines."
-    override val usage = "clr"
-    override val aliases = listOf("clr")
-    override val minArgs = 0
-    override val maxArgs = 0
-    override val requiresFile = false
-    override val fileExtension = ""
+    override val info = CommandInfo(
+        description = "Clear the screen",
+        longDescription = "Clear the screen by printing multiple empty lines.",
+        usage = "clr",
+        aliases = listOf("clr"),
+        minArgs = 0,
+        maxArgs = 0,
+        requiresFile = false,
+        fileExtension = ""
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/ExitCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/ExitCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.cli
 import pt.clilib.tools.*
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import kotlin.system.exitProcess
 
 /**
@@ -13,9 +14,11 @@ import kotlin.system.exitProcess
  * Não recebe argumentos.
  */
 object ExitCmd : Command {
-    override val description = "Exit the application"
-    override val usage = "exit"
-    override val aliases = listOf("e", "exit")
+    override val info = CommandInfo(
+        description = "Exit the application",
+        usage = "exit",
+        aliases = listOf("e", "exit")
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/HelpCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/HelpCmd.kt
@@ -2,6 +2,7 @@ package pt.clilib.cmdUtils.commands.cli
 
 import pt.clilib.cmdUtils.CmdRegister
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 
 /**
@@ -14,12 +15,14 @@ import pt.clilib.tools.*
  * Não necessita de argumentos.
  */
 object HelpCmd : Command {
-    override val description = "Show help information"
-    override val longDescription = "Show all available cmdUtils.commands and their usage."
-    override val usage = "help [command]"
-    override val aliases = listOf("h", "help")
-    override val minArgs = 0
-    override val maxArgs = 1
+    override val info = CommandInfo(
+        description = "Show help information",
+        longDescription = "Show all available cmdUtils.commands and their usage.",
+        usage = "help [command]",
+        aliases = listOf("h", "help"),
+        minArgs = 0,
+        maxArgs = 1
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/MkCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/MkCmd.kt
@@ -2,6 +2,7 @@ package pt.clilib.cmdUtils.commands.cli
 
 import pt.clilib.cmdUtils.CmdRegister
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.CYAN
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
@@ -10,14 +11,16 @@ import pt.clilib.tools.readJsonFile
 import pt.clilib.tools.validateArgs
 
 object MkCmd : Command {
-    override val description = "Cria um comando simples a partir de um ficheiro JSON"
-    override val longDescription = "Permite criar comandos simples que apenas imprimem uma mensagem fixa, definida num ficheiro JSON."
-    override val usage = "mkcmd <ficheiro.json>"
-    override val aliases = listOf("mkcmd")
-    override val minArgs = 1
-    override val maxArgs = 1
-    override val requiresFile = true
-    override val fileExtension = ".json"
+    override val info = CommandInfo(
+        description = "Create a simple command from a JSON file",
+        longDescription = "Allows creating simple commands that only print a fixed message defined in a JSON file.",
+        usage = "mkcmd <file.json>",
+        aliases = listOf("mkcmd"),
+        minArgs = 1,
+        maxArgs = 1,
+        requiresFile = true,
+        fileExtension = ".json"
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
@@ -39,14 +42,16 @@ object MkCmd : Command {
                 return@readJsonFile false
             }
             val customCmd = object : Command {
-                override val description = description
-                override val longDescription = longDescription
-                override val usage = usage
-                override val aliases = aliases
-                override val minArgs = minArgs
-                override val maxArgs = maxArgs
-                override val requiresFile = requiresFile
-                override val fileExtension = fileExtension
+                override val info = CommandInfo(
+                    description = description,
+                    longDescription = longDescription,
+                    usage = usage,
+                    aliases = aliases,
+                    minArgs = minArgs,
+                    maxArgs = maxArgs,
+                    requiresFile = requiresFile,
+                    fileExtension = fileExtension
+                )
 
                 override fun run(args: List<String>): Boolean {
                     if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/PrintCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/PrintCmd.kt
@@ -1,20 +1,23 @@
 package pt.clilib.cmdUtils.commands.cli
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 
 /**
  * Imprime no terminal todos os argumentos passados ao comando.
  */
 object PrintCmd : Command {
-    override val description = "Print argument"
-    override val longDescription = "Print the provided arguments to the terminal."
-    override val usage = "print <words>"
-    override val aliases = listOf("print")
-    override val minArgs = 0
-    override val maxArgs = -1
-    override val requiresFile = false
-    override val fileExtension = ""
+    override val info = CommandInfo(
+        description = "Print argument",
+        longDescription = "Print the provided arguments to the terminal.",
+        usage = "print <words>",
+        aliases = listOf("print"),
+        minArgs = 0,
+        maxArgs = -1,
+        requiresFile = false,
+        fileExtension = ""
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/VersionCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/VersionCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.cli
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.CYAN
 import pt.clilib.tools.RESET
 import pt.clilib.tools.YELLOW
@@ -12,9 +13,11 @@ import pt.clilib.tools.version
  */
 object VersionCmd : Command {
 
-    override val description = "Show version information and credits"
-    override val usage = "version"
-    override val aliases = listOf("version")
+    override val info = CommandInfo(
+        description = "Show version information and credits",
+        usage = "version",
+        aliases = listOf("version")
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WaitCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WaitCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.cli
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 
 /**
@@ -14,12 +15,14 @@ import pt.clilib.tools.*
  */
 
 object WaitCmd : Command {
-    override val description = "Wait for a specified time"
-    override val longDescription = "Wait for a specified time in milliseconds."
-    override val usage = "wait <milliseconds>"
-    override val aliases = listOf("wait", "w")
-    override val minArgs = 1
-    override val maxArgs = 1
+    override val info = CommandInfo(
+        description = "Wait for a specified time",
+        longDescription = "Wait for a specified time in milliseconds.",
+        usage = "wait <milliseconds>",
+        aliases = listOf("wait", "w"),
+        minArgs = 1,
+        maxArgs = 1
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WaitForCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WaitForCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.cli
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 
 /**
@@ -14,12 +15,14 @@ import pt.clilib.tools.*
  */
 
 object WaitForCmd : Command {
-        override val description = "Wait for user input"
-        override val longDescription = "Wait for user input before proceeding."
-        override val usage = "wfu [message]"
-        override val aliases = listOf("waitforuser", "wfu")
-        override val minArgs = 0
-        override val maxArgs = -1
+        override val info = CommandInfo(
+            description = "Wait for user input",
+            longDescription = "Wait for user input before proceeding.",
+            usage = "wfu [message]",
+            aliases = listOf("waitforuser", "wfu"),
+            minArgs = 0,
+            maxArgs = -1
+        )
 
         override fun run(args: List<String>): Boolean {
             if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WindowCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WindowCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.cli
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import java.io.PrintStream
 import pt.clilib.tools.validateArgs
@@ -8,14 +9,16 @@ import pt.clilib.tools.root
 import java.awt.Color
 
 object WindowCmd : Command {
-    override val description = "Open a new terminal window"
-    override val longDescription = "Open a new terminal window with the same session."
-    override val usage = "window"
-    override val aliases = listOf("window")
-    override val minArgs = 0
-    override val maxArgs = 0
-    override val requiresFile = false
-    override val fileExtension = ""
+    override val info = CommandInfo(
+        description = "Open a new terminal window",
+        longDescription = "Open a new terminal window with the same session.",
+        usage = "window",
+        aliases = listOf("window"),
+        minArgs = 0,
+        maxArgs = 0,
+        requiresFile = false,
+        fileExtension = ""
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/CdCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/CdCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.directory
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import java.io.File
 
@@ -8,14 +9,16 @@ import java.io.File
  * Muda o diretório atual para outro especificado ou para o diretório anterior com "..".
  */
 object CdCmd : Command {
-    override val description = "Change directory"
-    override val longDescription = "Change the current directory to a specified relative directory or to the parent directory with '..'."
-    override val usage = "cd <directory>"
-    override val aliases = listOf("cd")
-    override val minArgs = 1
-    override val maxArgs = 1
-    override val requiresFile = false
-    override val fileExtension = ""
+    override val info = CommandInfo(
+        description = "Change directory",
+        longDescription = "Change the current directory to a specified relative directory or to the parent directory with '..'.",
+        usage = "cd <directory>",
+        aliases = listOf("cd"),
+        minArgs = 1,
+        maxArgs = 1,
+        requiresFile = false,
+        fileExtension = ""
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/DelDirCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/DelDirCmd.kt
@@ -1,16 +1,19 @@
 package pt.clilib.cmdUtils.commands.directory
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 
 object DelDirCmd : Command {
-    override val description = "Delete a directory"
-    override val longDescription = "Deletes the specified directory from the filesystem."
-    override val usage = "deldir <directory_path>"
-    override val aliases = listOf("deldir", "rmdir")
-    override val minArgs = 1
-    override val maxArgs = 1
-    override val requiresFile = false
+    override val info = CommandInfo(
+        description = "Delete a directory",
+        longDescription = "Deletes the specified directory from the filesystem.",
+        usage = "deldir <directory_path>",
+        aliases = listOf("deldir", "rmdir"),
+        minArgs = 1,
+        maxArgs = 1,
+        requiresFile = false
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/LsCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/LsCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.directory
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import java.io.File
 
@@ -8,12 +9,14 @@ import java.io.File
  * Lista os ficheiros e pastas do diretório atual ou de um diretório relativo passado como argumento.
  */
 object LsCmd : Command {
-    override val description = "List files in the current directory"
-    override val longDescription = "List files in the current directory or a specified relative directory."
-    override val usage = "ls [directory]"
-    override val aliases = listOf("ls")
-    override val minArgs = 0
-    override val maxArgs = 1
+    override val info = CommandInfo(
+        description = "List files in the current directory",
+        longDescription = "List files in the current directory or a specified relative directory.",
+        usage = "ls [directory]",
+        aliases = listOf("ls"),
+        minArgs = 0,
+        maxArgs = 1
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/MkDirCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/MkDirCmd.kt
@@ -1,29 +1,32 @@
 package pt.clilib.cmdUtils.commands.directory
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import java.io.File
 
 object MkDirCmd : Command {
-    override val description = "Cria um diretório"
-    override val longDescription = "Cria um diretório com o nome especificado."
-    override val usage = "mkdir <diretório>"
-    override val aliases = listOf("mkdir")
-    override val minArgs = 1
-    override val maxArgs = 1
-    override val requiresFile = false
-    override val fileExtension = ""
+    override val info = CommandInfo(
+        description = "Create a directory",
+        longDescription = "Create a directory with the specified name.",
+        usage = "mkdir <directory>",
+        aliases = listOf("mkdir"),
+        minArgs = 1,
+        maxArgs = 1,
+        requiresFile = false,
+        fileExtension = ""
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
         val dirName = args[0]
         val dir = File(dirName)
         return if (dir.exists()) {
-            println("${RED}App Error: O diretório $dirName já existe.$RESET")
+            println("${RED}App Error: Directory $dirName already exists.$RESET")
             false
         } else {
             dir.mkdirs()
-            println("${CYAN}Diretório $dirName criado com sucesso!$RESET")
+            println("${CYAN}Directory $dirName created successfully!$RESET")
             true
         }
     }

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/DelFileCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/DelFileCmd.kt
@@ -1,16 +1,19 @@
 package pt.clilib.cmdUtils.commands.file
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 
 object DelFileCmd : Command {
-    override val description = "Delete a file"
-    override val longDescription = "Deletes the specified file from the filesystem."
-    override val usage = "delfile <file_path>"
-    override val aliases = listOf("delfile", "rmfile")
-    override val minArgs = 1
-    override val maxArgs = 1
-    override val requiresFile = false
+    override val info = CommandInfo(
+        description = "Delete a file",
+        longDescription = "Deletes the specified file from the filesystem.",
+        usage = "delfile <file_path>",
+        aliases = listOf("delfile", "rmfile"),
+        minArgs = 1,
+        maxArgs = 1,
+        requiresFile = false
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/EditCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/EditCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.file
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.CYAN
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
@@ -9,14 +10,16 @@ import pt.clilib.tools.validateArgs
 import java.io.File
 
 object EditCmd : Command {
-    override val description = "Edit a file"
-    override val longDescription = "Edit a file using the default editor."
-    override val usage = "edit <file>"
-    override val aliases = listOf("edit")
-    override val minArgs = 1
-    override val maxArgs = 1
-    override val requiresFile = true
-    override val fileExtension = ""
+    override val info = CommandInfo(
+        description = "Edit a file",
+        longDescription = "Edit a file using the default editor.",
+        usage = "edit <file>",
+        aliases = listOf("edit"),
+        minArgs = 1,
+        maxArgs = 1,
+        requiresFile = true,
+        fileExtension = ""
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
@@ -39,7 +42,7 @@ object EditCmd : Command {
             println("${CYAN}File $fileName edited successfully!${RESET}")
             true
         } else {
-            println("${RED}App Error: O arquivo $fileName não existe.${RESET}")
+            println("${RED}App Error: File $fileName does not exist.${RESET}")
             false
         }
     }

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkFileCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkFileCmd.kt
@@ -1,29 +1,32 @@
 package pt.clilib.cmdUtils.commands.file
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import java.io.File
 
 object MkFileCmd : Command {
-    override val description = "Cria um arquivo"
-    override val longDescription = "Cria um arquivo com o nome especificado."
-    override val usage = "mkfile <arquivo>"
-    override val aliases = listOf("mkfile")
-    override val minArgs = 1
-    override val maxArgs = 1
-    override val requiresFile = false
-    override val fileExtension = ""
+    override val info = CommandInfo(
+        description = "Create a file",
+        longDescription = "Create a file with the specified name.",
+        usage = "mkfile <file>",
+        aliases = listOf("mkfile"),
+        minArgs = 1,
+        maxArgs = 1,
+        requiresFile = false,
+        fileExtension = ""
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
         val fileName = args[0]
         val file = File(fileName)
         return if (file.exists()) {
-            println("${RED}App Error: O arquivo $fileName já existe.$RESET")
+            println("${RED}App Error: File $fileName already exists.$RESET")
             false
         } else {
             file.createNewFile()
-            println("${CYAN}Arquivo $fileName criado com sucesso!$RESET")
+            println("${CYAN}File $fileName created successfully!$RESET")
             true
         }
     }

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkTemplateCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkTemplateCmd.kt
@@ -1,30 +1,33 @@
 package pt.clilib.cmdUtils.commands.file
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import java.io.File
 
 object MkTemplateCmd : Command {
-    override val description = "Cria um ficheiro JSON de template para comandos customizados"
-    override val longDescription = "Gera um ficheiro JSON de exemplo para criar comandos simples via mkcmd."
-    override val usage = "mkcmdtemplate <nome_do_ficheiro.json>"
-    override val aliases = listOf("mkcmdtemplate", "mkcmdtpl")
-    override val minArgs = 1
-    override val maxArgs = 1
-    override val requiresFile = false
+    override val info = CommandInfo(
+        description = "Create a template JSON file for custom commands",
+        longDescription = "Generate a JSON example used to create simple commands via mkcmd.",
+        usage = "mkcmdtemplate <file.json>",
+        aliases = listOf("mkcmdtemplate", "mkcmdtpl"),
+        minArgs = 1,
+        maxArgs = 1,
+        requiresFile = false
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
         val fileName = if (args[0].endsWith(".json")) args[0] else args[0] + ".json"
         val file = File(root + fileName)
         if (file.exists()) {
-            println("${RED}App Error: O ficheiro $fileName já existe.$RESET")
+            println("${RED}App Error: File $fileName already exists.$RESET")
             return false
         }
         val template = """
         {
-          "description": "Descrição do comando",
-          "longDescription": "Descrição longa do comando.",
+          "description": "Command description",
+          "longDescription": "Long command description.",
           "usage": "nome_do_comando",
           "aliases": ["nome_do_comando", "alias"],
           "minArgs": 1,
@@ -35,7 +38,7 @@ object MkTemplateCmd : Command {
         }
         """.trimIndent()
         file.writeText(template)
-        println("${CYAN}Template criado em: $fileName$RESET")
+        println("${CYAN}Template created at: $fileName$RESET")
         return true
     }
 }

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/FunCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/FunCmd.kt
@@ -4,6 +4,7 @@ import pt.clilib.FunRegister
 import pt.clilib.LAST_CMD_KEY
 import pt.clilib.cmdUtils.CmdRegister
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
 import pt.clilib.tools.YELLOW
@@ -12,15 +13,16 @@ import pt.clilib.tools.cmdParser
 import pt.clilib.tools.validateArgs
 
 object FunCmd : Command {
-    override val description = "Create a function"
-    override val longDescription =
-        "Create a function with the given name and commands. The function can be called later."
-    override val usage = "fun <name> {commands}"
-    override val aliases = listOf("fun", "function")
-    override val minArgs = 1
-    override val maxArgs = -1
-    override val commands = listOf(
-        "-h", "--help"
+    override val info = CommandInfo(
+        description = "Create a function",
+        longDescription = "Create a function with the given name and commands. The function can be called later.",
+        usage = "fun <name> {commands}",
+        aliases = listOf("fun", "function"),
+        minArgs = 1,
+        maxArgs = -1,
+        commands = listOf(
+            "-h", "--help"
+        )
     )
 
     // Argument commands:
@@ -52,13 +54,15 @@ object FunCmd : Command {
 
             val functionCommand =
                 object : Command{
-                    override val description = "Function '${args[0]}'"
-                    override val longDescription = "Function '${args[0]}' with commands: $value"
-                    override val usage = "fun ${args[0]} {commands}"
-                    override val aliases = listOf(args[0])
-                    override val minArgs = 0
-                    override val maxArgs = -1
-                    override val commands = emptyList<String>()
+                    override val info = CommandInfo(
+                        description = "Function '${args[0]}'",
+                        longDescription = "Function '${args[0]}' with commands: $value",
+                        usage = "fun ${args[0]} {commands}",
+                        aliases = listOf(args[0]),
+                        minArgs = 0,
+                        maxArgs = -1,
+                        commands = emptyList()
+                    )
 
                     private val body = value.removeSurrounding("{", "}")
 

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/IfCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/IfCmd.kt
@@ -1,20 +1,23 @@
 package pt.clilib.cmdUtils.commands.functions
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.cmdParser
 import pt.clilib.tools.eval
 import pt.clilib.tools.replaceVars
 import pt.clilib.tools.validateArgs
 
 object IfCmd : Command {
-    override val description = "Create an if statement"
-    override val longDescription = "Create an if statement with the given condition. The commands will be executed if the condition is true."
-    override val usage = "if <condition> [commands]"
-    override val aliases = listOf("if")
-    override val minArgs = 1
-    override val maxArgs = -1
-    override val commands = listOf(
-        "-h", "--help"
+    override val info = CommandInfo(
+        description = "Create an if statement",
+        longDescription = "Create an if statement with the given condition. The commands will be executed if the condition is true.",
+        usage = "if <condition> [commands]",
+        aliases = listOf("if"),
+        minArgs = 1,
+        maxArgs = -1,
+        commands = listOf(
+            "-h", "--help"
+        )
     )
 
     override fun run(args: List<String>): Boolean {

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/LoadScriptCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/LoadScriptCmd.kt
@@ -2,6 +2,7 @@ package pt.clilib.cmdUtils.commands.functions
 
 import pt.clilib.tools.*
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import java.io.File
 
 /**
@@ -16,14 +17,16 @@ import java.io.File
 
 object LoadScriptCmd : Command {
 
-        override val description = "Load a script file"
-        override val longDescription = "Load and execute a script file containing a series of cmdUtils.commands."
-        override val usage = "loadscript <script_file>"
-        override val aliases = listOf("loadscript", "lscript")
-        override val minArgs = 1
-        override val maxArgs = 1
-        override val requiresFile = true
-        override val fileExtension = ".ppc"
+        override val info = CommandInfo(
+            description = "Load a script file",
+            longDescription = "Load and execute a script file containing a series of commands.",
+            usage = "loadscript <script_file>",
+            aliases = listOf("loadscript", "lscript"),
+            minArgs = 1,
+            maxArgs = 1,
+            requiresFile = true,
+            fileExtension = ".ppc"
+        )
 
         override fun run(args: List<String>): Boolean {
             if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/MeasureCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/MeasureCmd.kt
@@ -2,6 +2,7 @@ package pt.clilib.cmdUtils.commands.functions
 
 import pt.clilib.VarRegister
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import kotlin.time.measureTime
 
@@ -15,12 +16,14 @@ import kotlin.time.measureTime
  * Aceita qualquer comando como argumento. Útil para testes de desempenho.
  */
 object MeasureCmd : Command {
-    override val description = "Measure the time taken by a command"
-    override val longDescription = "Measure the time taken to execute a command. Useful for performance testing."
-    override val usage = "measure <command>"
-    override val aliases = listOf("measure", "m", "time")
-    override val minArgs = 1
-    override val maxArgs = -1
+    override val info = CommandInfo(
+        description = "Measure the time taken by a command",
+        longDescription = "Measure the time taken to execute a command. Useful for performance testing.",
+        usage = "measure <command>",
+        aliases = listOf("measure", "m", "time"),
+        minArgs = 1,
+        maxArgs = -1
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/VarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/VarCmd.kt
@@ -4,21 +4,24 @@ import pt.clilib.VarRegister
 import pt.clilib.LAST_CMD_KEY
 import pt.clilib.cmdUtils.CmdRegister
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import pt.clilib.tools.isValidIdentifier
 
 
 object VarCmd : Command {
-    override val description = "Create or modify a variable"
-    override val longDescription = "Create or modify a variable with the given name and value. "
-    override val usage = "var <name> [args]"
-    override val aliases = listOf("var")
-    override val minArgs = 1
-    override val maxArgs = -1
-    override val commands = listOf(
-        "-d", "--delete",
-        "-l", "--list",
-        "-h", "--help"
+    override val info = CommandInfo(
+        description = "Create or modify a variable",
+        longDescription = "Create or modify a variable with the given name and value.",
+        usage = "var <name> [args]",
+        aliases = listOf("var"),
+        minArgs = 1,
+        maxArgs = -1,
+        commands = listOf(
+            "-d", "--delete",
+            "-l", "--list",
+            "-h", "--help"
+        )
     )
 
 

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/WhileCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/WhileCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.functions
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
 import pt.clilib.tools.cmdParser
@@ -9,15 +10,17 @@ import pt.clilib.tools.replaceVars
 import pt.clilib.tools.validateArgs
 
 object WhileCmd : Command {
-    override val description = "Create a while loop"
-    override val longDescription = "Create a while loop with the given condition. The loop will continue until the condition is false."
-    override val usage = "while <condition> [commands]"
-    override val aliases = listOf("while")
-    override val minArgs = 1
-    override val maxArgs = -1
-    override val commands = listOf(
-        "-b", "--break",
-        "-h", "--help"
+    override val info = CommandInfo(
+        description = "Create a while loop",
+        longDescription = "Create a while loop with the given condition. The loop will continue until the condition is false.",
+        usage = "while <condition> [commands]",
+        aliases = listOf("while"),
+        minArgs = 1,
+        maxArgs = -1,
+        commands = listOf(
+            "-b", "--break",
+            "-h", "--help"
+        )
     )
 
     override fun run(args: List<String>): Boolean {

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/AddVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/AddVarCmd.kt
@@ -1,18 +1,21 @@
 package pt.clilib.cmdUtils.commands.varOp
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import pt.clilib.tools.ArithmeticOperator
 import pt.clilib.tools.performVarOperation
 
 // Adds two variables together, or creates a new variable with the result.
 object AddVarCmd : Command{
-    override val description = "Add two variables together"
-    override val longDescription = "Adds the values of two variables and creates a new variable with the result."
-    override val usage = "add <var1> <var2> <resultVar>"
-    override val aliases = listOf("add", "plus")
-    override val minArgs = 2
-    override val maxArgs = 3
+    override val info = CommandInfo(
+        description = "Add two variables together",
+        longDescription = "Adds the values of two variables and creates a new variable with the result.",
+        usage = "add <var1> <var2> <resultVar>",
+        aliases = listOf("add", "plus"),
+        minArgs = 2,
+        maxArgs = 3
+    )
 
     override fun run(args: List<String>): Boolean {
         return performVarOperation(args, this, ArithmeticOperator.ADD)

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/DivVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/DivVarCmd.kt
@@ -1,17 +1,20 @@
 package pt.clilib.cmdUtils.commands.varOp
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import pt.clilib.tools.ArithmeticOperator
 import pt.clilib.tools.performVarOperation
 
 object DivVarCmd : Command {
-    override val description = "Divide two variables"
-    override val longDescription = "Divides the value of one variable by another and creates a new variable with the result."
-    override val usage = "div <var1> <var2> <resultVar>"
-    override val aliases = listOf("div", "divide")
-    override val minArgs = 2
-    override val maxArgs = 3
+    override val info = CommandInfo(
+        description = "Divide two variables",
+        longDescription = "Divides the value of one variable by another and creates a new variable with the result.",
+        usage = "div <var1> <var2> <resultVar>",
+        aliases = listOf("div", "divide"),
+        minArgs = 2,
+        maxArgs = 3
+    )
 
     override fun run(args: List<String>): Boolean {
         return performVarOperation(args, this, ArithmeticOperator.DIVIDE)

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/ExprVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/ExprVarCmd.kt
@@ -2,15 +2,18 @@ package pt.clilib.cmdUtils.commands.varOp
 
 import pt.clilib.VarRegister
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 
 object ExprVarCmd : Command {
-    override val description = "Evaluate an expression"
-    override val longDescription = "Evaluates a mathematical expression."
-    override val usage = "expr <expression>"
-    override val aliases = listOf("expr", "evaluate")
-    override val minArgs = 1
-    override val maxArgs = -1
+    override val info = CommandInfo(
+        description = "Evaluate an expression",
+        longDescription = "Evaluates a mathematical expression.",
+        usage = "expr <expression>",
+        aliases = listOf("expr", "evaluate"),
+        minArgs = 1,
+        maxArgs = -1
+    )
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/MultVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/MultVarCmd.kt
@@ -1,17 +1,20 @@
 package pt.clilib.cmdUtils.commands.varOp
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import pt.clilib.tools.ArithmeticOperator
 import pt.clilib.tools.performVarOperation
 
 object MultVarCmd : Command {
-    override val description = "Multiply two variables"
-    override val longDescription = "Multiplies the value of one variable by another and creates a new variable with the result."
-    override val usage = "mult <var1> <var2> <resultVar>"
-    override val aliases = listOf("mult", "times")
-    override val minArgs = 2
-    override val maxArgs = 3
+    override val info = CommandInfo(
+        description = "Multiply two variables",
+        longDescription = "Multiplies the value of one variable by another and creates a new variable with the result.",
+        usage = "mult <var1> <var2> <resultVar>",
+        aliases = listOf("mult", "times"),
+        minArgs = 2,
+        maxArgs = 3
+    )
 
     override fun run(args: List<String>): Boolean {
         return performVarOperation(args, this, ArithmeticOperator.MULTIPLY)

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/SubVarCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/varOp/SubVarCmd.kt
@@ -1,17 +1,20 @@
 package pt.clilib.cmdUtils.commands.varOp
 
 import pt.clilib.cmdUtils.Command
+import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import pt.clilib.tools.ArithmeticOperator
 import pt.clilib.tools.performVarOperation
 
 object SubVarCmd : Command {
-    override val description = "Subtract two variables"
-    override val longDescription = "Subtracts the value of one variable from another and creates a new variable with the result."
-    override val usage = "sub <var1> <var2> <resultVar>"
-    override val aliases = listOf("sub", "minus")
-    override val minArgs = 2
-    override val maxArgs = 3
+    override val info = CommandInfo(
+        description = "Subtract two variables",
+        longDescription = "Subtracts the value of one variable from another and creates a new variable with the result.",
+        usage = "sub <var1> <var2> <resultVar>",
+        aliases = listOf("sub", "minus"),
+        minArgs = 2,
+        maxArgs = 3
+    )
 
     override fun run(args: List<String>): Boolean {
         return performVarOperation(args, this, ArithmeticOperator.SUBTRACT)


### PR DESCRIPTION
## Summary
- translate documentation to English
- introduce `CommandInfo` and update `Command` interface
- refactor commands to use the new metadata structure

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6850aa6807988332a634ee57aaead911