### PR TITLE
Refactor environment handling and add color helpers

### DIFF
--- a/src/main/kotlin/pt/clilib/CLI.kt
+++ b/src/main/kotlin/pt/clilib/CLI.kt
@@ -28,7 +28,8 @@ class CLI() {
     var title : String = "CLI App"
     var bgColor : Color = Color.BLACK
     var fgColor : Color = Color.WHITE
-    var prompt : String = "${GRAY}${root} >> $RESET"
+    val prompt: String
+        get() = "${GRAY}${Environment.prompt} >> $RESET"
 
     var useExternalWindow = false
 
@@ -57,7 +58,7 @@ class CLI() {
         else {
             clearAndRedrawPrompt()
             while (true) {
-                print("${GRAY}${root} >> $RESET")
+                print(prompt)
                 val input = readLine()
                 cmdParser(input)
             }
@@ -83,7 +84,7 @@ class CLI() {
      * @param file O caminho do ficheiro a ser lido.
      */
     fun runFromFile(file: String) {
-        val file = File(file)
+        val file = Environment.resolve(file).toFile()
         if (!file.exists()) {
             println("${RED}App Error: File not found: $file$RESET")
             return

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/PrintCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/PrintCmd.kt
@@ -21,7 +21,7 @@ object PrintCmd : Command {
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
-        println("${GREEN}${args.joinToString(" ")}${RESET}")
+        println(args.joinToString(" ").colorize(AnsiColor.GREEN))
         return true
     }
 }

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WindowCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/cli/WindowCmd.kt
@@ -5,7 +5,7 @@ import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
 import java.io.PrintStream
 import pt.clilib.tools.validateArgs
-import pt.clilib.tools.root
+import pt.clilib.tools.Environment
 import java.awt.Color
 
 object WindowCmd : Command {
@@ -26,7 +26,7 @@ object WindowCmd : Command {
             title = "CLI App - $version",
             bgColor = Color.BLACK,
             fgColor = Color.WHITE,
-            prompt = "${GRAY}${root} >> ${RESET}"
+            prompt = "${GRAY}${Environment.prompt} >> ${RESET}"
         )
         // redireciona saída
         val stream = ConsoleOutputStream(terminal)

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/CdCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/CdCmd.kt
@@ -3,7 +3,6 @@ package pt.clilib.cmdUtils.commands.directory
 import pt.clilib.cmdUtils.Command
 import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.*
-import java.io.File
 
 /**
  * Muda o diretório atual para outro especificado ou para o diretório anterior com "..".
@@ -23,14 +22,17 @@ object CdCmd : Command {
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
         try {
-            val path = args[0]
-            if (path == "..") {
-                root = root.dropLast(1).dropLastWhile { it != '/' && it != '\\' }
-            } else if (File("$root$path").isDirectory()) {
-                root += "$path\\"
+            val pathArg = args[0]
+            if (pathArg == "..") {
+                Environment.root = Environment.root.parent ?: Environment.root
             } else {
-                println("${RED}App Error: Path does not exist or is invalid: $path$RESET")
-                return false
+                val target = Environment.resolve(pathArg)
+                if (target.toFile().isDirectory) {
+                    Environment.root = target
+                } else {
+                    println("${RED}App Error: Path does not exist or is invalid: $pathArg$RESET")
+                    return false
+                }
             }
         } catch (e: Exception) {
             println("${RED}App Error: Failed to change directory. ${e.message}$RESET")

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/LsCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/directory/LsCmd.kt
@@ -20,13 +20,14 @@ object LsCmd : Command {
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
-        val path = if (args.isNotEmpty()) "$root${args[0]}" else root
-        val target = File(path)
+        val path = if (args.isNotEmpty()) Environment.resolve(args[0]) else Environment.root
+        val target = path.toFile()
+        val displayPath = path.toString()
         if (!target.exists() || !target.isDirectory) {
-            println("${RED}App Error: Directory does not exist or is invalid: $path$RESET")
+            println("${RED}App Error: Directory does not exist or is invalid: $displayPath$RESET")
             return false
         }
-        println("${GREEN}Files in ${path.ifEmpty { "current" }} directory:$RESET")
+        println("${GREEN}Files in ${displayPath.ifEmpty { "current" }} directory:$RESET")
         printFlatDirectoryTree(target)
         return true
     }

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/EditCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/EditCmd.kt
@@ -5,9 +5,8 @@ import pt.clilib.cmdUtils.CommandInfo
 import pt.clilib.tools.CYAN
 import pt.clilib.tools.RED
 import pt.clilib.tools.RESET
-import pt.clilib.tools.root
+import pt.clilib.tools.Environment
 import pt.clilib.tools.validateArgs
-import java.io.File
 
 object EditCmd : Command {
     override val info = CommandInfo(
@@ -23,8 +22,8 @@ object EditCmd : Command {
 
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
-        val fileName = root + args[0]
-        val file = File(fileName)
+        val file = Environment.resolve(args[0]).toFile()
+        val fileName = file.absolutePath
         return if (file.exists()) {
             println("${CYAN}Editing $fileName...${RESET}")
             // Open the file in the default editor for windows, mac and linux

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkTemplateCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/file/MkTemplateCmd.kt
@@ -19,7 +19,7 @@ object MkTemplateCmd : Command {
     override fun run(args: List<String>): Boolean {
         if (!validateArgs(args, this)) return false
         val fileName = if (args[0].endsWith(".json")) args[0] else args[0] + ".json"
-        val file = File(root + fileName)
+        val file = Environment.resolve(fileName).toFile()
         if (file.exists()) {
             println("${RED}App Error: File $fileName already exists.$RESET")
             return false

--- a/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/LoadScriptCmd.kt
+++ b/src/main/kotlin/pt/clilib/cmdUtils/commands/functions/LoadScriptCmd.kt
@@ -1,6 +1,7 @@
 package pt.clilib.cmdUtils.commands.functions
 
 import pt.clilib.tools.*
+import pt.clilib.tools.Environment
 import pt.clilib.cmdUtils.Command
 import pt.clilib.cmdUtils.CommandInfo
 import java.io.File
@@ -30,12 +31,12 @@ object LoadScriptCmd : Command {
 
         override fun run(args: List<String>): Boolean {
             if (!validateArgs(args, this)) return false
-            val prevRoot = root
+            val prevRoot = Environment.root
             println("${YELLOW}Loading script: ${args[0]}${RESET}")
             try {
-                val file = File(root + args[0])
+                val file = Environment.resolve(args[0]).toFile()
                 val lines = file.readLines()
-                root = System.getProperty("user.dir") + "\\"
+                Environment.changeRoot(System.getProperty("user.dir"))
                 for (line in lines) {
                     if (!line.trim().startsWith(commentCode)) {
                         if (!cmdParser(line)) {
@@ -48,7 +49,7 @@ object LoadScriptCmd : Command {
                 println("${RED}App Error: Failed to load script. ${e.message}${RESET}")
                 return false
             }
-            root = prevRoot
+            Environment.root = prevRoot
             return true
         }
 }

--- a/src/main/kotlin/pt/clilib/tools/Colors.kt
+++ b/src/main/kotlin/pt/clilib/tools/Colors.kt
@@ -3,16 +3,33 @@ package pt.clilib.tools
 // File that stores the ANSI color codes used in the project
 // ANSI Colors
 
-internal const val RESET = "\u001B[0m"
-internal const val BLUE = "\u001B[34m"
-internal const val GREEN = "\u001B[32m"
-internal const val RED = "\u001B[31m"
-internal const val YELLOW = "\u001B[33m"
-internal const val CYAN = "\u001B[36m"
-internal const val GRAY = "\u001B[90m"
-internal const val ORANGE = "\u001B[38;5;214m"
-internal const val MAGENTA = "\u001B[35m"
-internal const val WHITE = "\u001B[37m"
-internal const val BLACK = "\u001B[30m"
-internal const val BOLD = "\u001B[1m"
+internal enum class AnsiColor(val code: String) {
+    RESET("\u001B[0m"),
+    BLUE("\u001B[34m"),
+    GREEN("\u001B[32m"),
+    RED("\u001B[31m"),
+    YELLOW("\u001B[33m"),
+    CYAN("\u001B[36m"),
+    GRAY("\u001B[90m"),
+    ORANGE("\u001B[38;5;214m"),
+    MAGENTA("\u001B[35m"),
+    WHITE("\u001B[37m"),
+    BLACK("\u001B[30m"),
+    BOLD("\u001B[1m");
+}
+
+internal val RESET = AnsiColor.RESET.code
+internal val BLUE = AnsiColor.BLUE.code
+internal val GREEN = AnsiColor.GREEN.code
+internal val RED = AnsiColor.RED.code
+internal val YELLOW = AnsiColor.YELLOW.code
+internal val CYAN = AnsiColor.CYAN.code
+internal val GRAY = AnsiColor.GRAY.code
+internal val ORANGE = AnsiColor.ORANGE.code
+internal val MAGENTA = AnsiColor.MAGENTA.code
+internal val WHITE = AnsiColor.WHITE.code
+internal val BLACK = AnsiColor.BLACK.code
+internal val BOLD = AnsiColor.BOLD.code
+
+internal fun String.colorize(color: AnsiColor): String = "${'$'}{color.code}${'$'}this${'$'}{AnsiColor.RESET.code}"
 

--- a/src/main/kotlin/pt/clilib/tools/Global.kt
+++ b/src/main/kotlin/pt/clilib/tools/Global.kt
@@ -1,6 +1,8 @@
 package pt.clilib.tools
 
 import java.io.File
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.Properties
 
 private class StatusService {
@@ -20,7 +22,24 @@ internal val version = StatusService().getVersion()
 */
 internal const val commentCode = "//"
 
-/**Guarda globalmente o caminho base que está a ser utilizado*/
-var root: String = File(System.getProperty("user.dir")).absolutePath + File.separator
-    get() = field.trimEnd('/', '\\') + File.separator
+/**
+ * Application environment settings.
+ */
+object Environment {
+    /** Root directory used by the CLI. */
+    var root: Path = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+
+    /** Returns [root] resolved with [path]. */
+    fun resolve(path: String): Path = root.resolve(path).normalize()
+
+    /** Changes the root directory. */
+    fun changeRoot(path: String) {
+        root = Paths.get(path).toAbsolutePath().normalize()
+    }
+
+    /** Formatted path string for prompt rendering. */
+    val prompt: String
+        get() = root.toString() + File.separator
+}
+
 

--- a/src/main/kotlin/pt/clilib/tools/Utils.kt
+++ b/src/main/kotlin/pt/clilib/tools/Utils.kt
@@ -9,7 +9,7 @@ import kotlin.random.Random
 import org.json.JSONObject
 
 internal fun readJsonFile(filePath: String, onJson: (JSONObject) -> Boolean): Boolean {
-    val file = File(root + filePath)
+    val file = Environment.resolve(filePath).toFile()
     if (!file.exists()) {
         println("${RED}App Error: Ficheiro não encontrado: $filePath$RESET")
         return false


### PR DESCRIPTION
## Summary
- centralize path management in new `Environment` object
- modernize color utilities with `AnsiColor` enum and `colorize` extension
- update CLI prompt and file commands to use new environment APIs
- use `colorize` helper in `PrintCmd`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6850afd908388332ac44a1fbe005a90b